### PR TITLE
piping and bug fix for when files are not UTF-8

### DIFF
--- a/bin/license_header
+++ b/bin/license_header
@@ -75,6 +75,7 @@ begin
 rescue EOFError, Errno::EWOULDBLOCK
 end
 required_files = piped_text.split("\n")
+@prompt = false if ! required_files.empty?
 
 if command.nil? or  ( ARGV.empty? and required_files.empty? )
   puts opts

--- a/lib/license_header/auditor.rb
+++ b/lib/license_header/auditor.rb
@@ -20,6 +20,7 @@ module LicenseHeader
     :haml       => { :pre => '-#',   :each => '  ',                  :sep => true,  :exts => %w(.haml)                 },
     :as         => { :pre => '/* ',  :each => ' * ', :post => '*/',  :sep => true,  :exts => %w(.as)                   },
     :html       => { :pre => '<!--', :each => '',    :post => '-->', :sep => false, :exts => %w(.html)                 },
+    :htm        => { :pre => '<!--', :each => '',    :post => '-->', :sep => false, :exts => %w(.htm)                  },
     :java       => { :pre => '/* ',  :each => ' * ', :post => '*/',  :sep => true,  :exts => %w(.java)                 },
     :javascript => { :pre => '/* ',  :each => ' * ', :post => '*/',  :sep => true,  :exts => %w(.js .json)             },
     :ruby       => {                 :each => '# ',                  :sep => true,  :exts => %w(.rb .rake .coffee .pp) },


### PR DESCRIPTION
Did I mess up the way targets works on line 89 of license_header ?

I put this in to handle a required list of files...

$ git log --pretty="%H %cn" | egrep -i "(colvar|klein|rogers|phuong)" | cut -d' ' -f1 | while read commit_hash; do git show --oneline --name-only $commit_hash | tail -n+2; done | sort | uniq | license_header -a --header-file=HEADER
